### PR TITLE
Add new endpoint to update status of a brand

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -65,11 +65,20 @@ type Brand {
   createdAt: DateTime!
   updatedAt: DateTime!
   name: String!
+  status: BrandStatus!
   logoUrl: String
   sector: [Sector!]
   adAccounts: [String!]
   socialAccounts: [String!]
   businessAccount: BusinessAccount!
+}
+
+"""Brand Status"""
+enum BrandStatus {
+  IN_PROGRESS
+  DATA_READY
+  MODEL_TRAINING
+  READY
 }
 
 enum Sector {
@@ -130,6 +139,9 @@ type Mutation {
   """Updates optional fields of a brand"""
   updateBrand(input: UpdateBrandInput!, brandId: String!): Brand!
 
+  """Updates status of a brand"""
+  updateBrandStatus(input: BrandStatusInput!, brandId: String!): Brand!
+
   """Updates assets of a brand"""
   updateBrandAssets(input: BrandAssetsInput!, brandId: String!): Brand!
 
@@ -185,6 +197,10 @@ input UpdateBrandInput {
   name: String
   logoUrl: String
   sector: [Sector!]
+}
+
+input BrandStatusInput {
+  status: BrandStatus!
 }
 
 input BrandAssetsInput {

--- a/src/database/intelligentSuiteMigrations/1691882263742-add_brand_status_column.ts
+++ b/src/database/intelligentSuiteMigrations/1691882263742-add_brand_status_column.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addBrandStatusColumn1691882263742 implements MigrationInterface {
+    name = "addBrandStatusColumn1691882263742";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE \`brand\` ADD \`status\` enum ('IN_PROGRESS', 'DATA_READY', 'MODEL_TRAINING', 'READY') NOT NULL DEFAULT 'IN_PROGRESS'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`brand\` DROP COLUMN \`status\``);
+    }
+}

--- a/src/intelligentSuite/brands/entities/Brand.ts
+++ b/src/intelligentSuite/brands/entities/Brand.ts
@@ -4,6 +4,7 @@ import {BaseEntity} from "../../../common/entities/BaseEntity";
 import {BusinessAccount} from "../../businessAccounts/entities/BusinessAccount";
 import {Sector} from "../../common/entities/Sector";
 import {CreateBrandInput, UpdateBrandInput} from "../input/BrandInput";
+import {BrandStatus} from "./BrandStatus";
 
 @ObjectType()
 @Entity()
@@ -11,6 +12,14 @@ export default class Brand extends BaseEntity {
     @Column()
     @Field()
     name!: string;
+
+    @Column({
+        type: "enum",
+        enum: BrandStatus,
+        default: BrandStatus.IN_PROGRESS,
+    })
+    @Field(() => BrandStatus)
+    status!: BrandStatus;
 
     @Column({nullable: true})
     @Field({nullable: true})

--- a/src/intelligentSuite/brands/input/BrandInput.ts
+++ b/src/intelligentSuite/brands/input/BrandInput.ts
@@ -1,6 +1,7 @@
 import {Field, InputType, Int} from "type-graphql";
 import {AdAccountType, SocialAccountType} from "../../common/entities/Assets";
 import {Sector} from "../../common/entities/Sector";
+import {BrandStatus} from "../entities/BrandStatus";
 
 @InputType()
 export class CreateBrandInput {
@@ -62,4 +63,10 @@ export class BrandColorPalleteInput {
 export class BrandLogoVariantInput {
     @Field(() => String)
     logoVariant!: string;
+}
+
+@InputType()
+export class BrandStatusInput {
+    @Field(() => BrandStatus)
+    status!: BrandStatus;
 }

--- a/src/intelligentSuite/brands/resolvers/BrandResolver.ts
+++ b/src/intelligentSuite/brands/resolvers/BrandResolver.ts
@@ -6,7 +6,7 @@ import {UploadDataResponse} from "../../fileHandler/entities/UploadDataResponse"
 import {User} from "../../users/entities/User";
 import Brand from "../entities/Brand";
 import {BrandAssetsResponse} from "../entities/BrandAssetsResponse";
-import {BrandAssetsInput, CreateBrandInput, UpdateBrandInput} from "../input/BrandInput";
+import {BrandAssetsInput, BrandStatusInput, CreateBrandInput, UpdateBrandInput} from "../input/BrandInput";
 import {BrandAccountsService} from "../service/BrandAccountsService";
 import {BrandService} from "../service/BrandService";
 
@@ -32,6 +32,15 @@ export class BrandResolver {
         @Arg("input") input: UpdateBrandInput,
     ) {
         return await this.brandService.updateBrand(user, brandId, input);
+    }
+
+    @Mutation((_returns) => Brand, {description: "Updates status of a brand"})
+    async updateBrandStatus(
+        @CurrentUser() user: User,
+        @Arg("brandId") brandId: string,
+        @Arg("input") input: BrandStatusInput,
+    ) {
+        return await this.brandService.updateBrandStatus(user, brandId, input);
     }
 
     @Mutation((_returns) => Brand, {description: "Updates assets of a brand"})

--- a/src/intelligentSuite/brands/service/BrandService.ts
+++ b/src/intelligentSuite/brands/service/BrandService.ts
@@ -5,7 +5,7 @@ import {UploadDataResponse} from "../../fileHandler/entities/UploadDataResponse"
 import {FileHandlerService} from "../../fileHandler/service/FileHandlerService";
 import {User} from "../../users/entities/User";
 import Brand from "../entities/Brand";
-import {CreateBrandInput, UpdateBrandInput} from "../input/BrandInput";
+import {BrandStatusInput, CreateBrandInput, UpdateBrandInput} from "../input/BrandInput";
 import {BrandRepository} from "../repository/BrandRepository";
 
 @Service()
@@ -36,6 +36,17 @@ export class BrandService extends BaseService {
         const updatedBrand = await this.brandRepository.save(brand);
 
         this.logger.debug(this.updateBrand.name, `Updated brand successfully`);
+        return updatedBrand;
+    }
+
+    async updateBrandStatus(user: User, brandId: string, input: BrandStatusInput) {
+        this.validateUserAdmin(user, this.updateBrandStatus.name);
+
+        const brand = user.getBrand(brandId);
+        brand.status = input.status;
+        const updatedBrand = await this.brandRepository.save(brand);
+
+        this.logger.debug(this.updateBrandStatus.name, `Updated brand status successfully`);
         return updatedBrand;
     }
 

--- a/thunder-client/collections/tc_col_memorable-test.json
+++ b/thunder-client/collections/tc_col_memorable-test.json
@@ -14,7 +14,7 @@
             "method": "POST",
             "sortNum": 20000,
             "created": "2023-07-03T09:31:53.814Z",
-            "modified": "2023-07-03T09:37:51.923Z",
+            "modified": "2023-08-13T00:09:23.946Z",
             "headers": [],
             "params": [],
             "body": {
@@ -72,7 +72,7 @@
             "method": "POST",
             "sortNum": 40000,
             "created": "2023-07-03T09:33:34.680Z",
-            "modified": "2023-07-03T09:41:10.206Z",
+            "modified": "2023-08-12T22:49:17.442Z",
             "headers": [
                 {
                     "name": "authorization",
@@ -100,7 +100,7 @@
             "method": "POST",
             "sortNum": 50000,
             "created": "2023-07-03T09:41:40.278Z",
-            "modified": "2023-07-03T09:44:02.226Z",
+            "modified": "2023-08-13T16:35:20.292Z",
             "headers": [
                 {
                     "name": "authorization",
@@ -113,7 +113,7 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "mutation createBrand($brand: CreateBrandInput!){\n    createBrand(input: $brand){\n        id,\n        name,\n        createdAt,\n        logoUrl,\n        sector,\n    }\n}",
+                    "query": "mutation createBrand($brand: CreateBrandInput!){\n    createBrand(input: $brand){\n        id,\n        name,\n        createdAt,\n        logoUrl,\n        sector,\n        status,\n    }\n}",
                     "variables": "{\n  \"brand\": {\n    \"name\": \"Pharma Global 2\",\n    \"sector\": [\"PharmaceuticalsAndBiotechnology\"],\n    \"logoUrl\":\"logoUrl\"\n  }\n}"
                 }
             },
@@ -128,7 +128,7 @@
             "method": "POST",
             "sortNum": 60000,
             "created": "2023-07-03T09:42:36.064Z",
-            "modified": "2023-07-03T09:44:08.438Z",
+            "modified": "2023-08-12T23:56:23.405Z",
             "headers": [
                 {
                     "name": "authorization",
@@ -141,8 +141,36 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "mutation updateBrand($brandId: String!, $brand: UpdateBrandInput!){\n    updateBrand(brandId: $brandId, input: $brand){\n        id,\n        name,\n        createdAt,\n        logoUrl,\n        sector,\n    }\n}",
-                    "variables": "{\n  \"brand\": {\n    \"name\": \"Pharma Global\",\n    \"logoUrl\":\"logoUrl\",\n    \"sector\": [\"Utilities\"]\n    \n  },\n  \"brandId\": \"01H2Q81MZ45Y2FVD2KB0SDTMXR\"\n}"
+                    "query": "mutation updateBrand($brandId: String!, $brand: UpdateBrandInput!){\n    updateBrand(brandId: $brandId, input: $brand){\n        id,\n        name,\n        createdAt,\n        logoUrl,\n        sector,\n        status\n    }\n}",
+                    "variables": "{\n  \"brand\": {\n    \"name\": \"Pharma Global 4\",\n    \"logoUrl\":\"logoUrl\",\n    \"sector\": [\"Utilities\"]\n    \n  },\n  \"brandId\": \"01H7P2VG6PK1YCTPCEX4WPSBCE\"\n}"
+                }
+            },
+            "tests": []
+        },
+        {
+            "_id": "67ea772c-6618-4321-9f13-3f2a8817c277",
+            "colId": "bdfbad21-e244-4370-bf29-ebc7989769c1",
+            "containerId": "",
+            "name": "update Brand Status",
+            "url": "{{baseUrl}}",
+            "method": "POST",
+            "sortNum": 70000,
+            "created": "2023-08-12T23:33:51.376Z",
+            "modified": "2023-08-13T16:36:01.312Z",
+            "headers": [
+                {
+                    "name": "authorization",
+                    "value": "Bearer {{token}}"
+                }
+            ],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation updateBrandStatus($brandId: String!, $input: BrandStatusInput!) {\n  updateBrandStatus(brandId: $brandId, input: $input) {\n    id\n    name\n    createdAt\n    logoUrl\n    sector\n    status\n  }\n}",
+                    "variables": "{\n  \"brandId\": \"01H7P2VG6PK1YCTPCEX4WPSBCE\",\n  \"input\": {\n    \"status\": \"READY\"\n  }\n}"
                 }
             },
             "tests": []


### PR DESCRIPTION
This pull request adds a new endpoint to change the status of a brand while ensuring that only administrators with access to the brand can perform this action.

![Screenshot from 2023-08-13 13-58-42](https://github.com/mdauner-priv/memorable-backend-test-fork/assets/139567083/a82f3f43-a9e0-4f6c-a066-755fafea37b6)


Changes Made:

- Added a new column `status` to the `Brand` entity
- Implemented a new endpoint `updateBrandStatus` for changing brand status.
- Added logic to validate administrator privileges and brand access before allowing the status change.
- Updated Thunder Client configuration for testing the new endpoint.